### PR TITLE
Add the ability to package the code for Lambda deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 node_modules/
 temp/
 coverage/
+package/
+LambdaFunction.zip
 npm-debug.log
 .DS_Store
 .idea

--- a/README.md
+++ b/README.md
@@ -20,11 +20,24 @@ console.log(dynamoIncrementalRestore.logbuildList({
     Prefix: "ServiceFolder/TableFolder/ClientID",  // Where the files sit. Use parent folders and it should recursively find all child document/files e.g. Formsmith/Formsmith.Blue.FormSchema/543
     DestinationTableName: "Example Table Name" ,// e.g. Formsmith.Blue.FormSchema
     Bucket: "au-backup-bucket-name", // e.g. pageup-dynamo-backup
-    restoreToPointInTime: new Date('2020-11-14T23:50:32.000Z'), //the last point in time you want to update a version
+    restoreToPointInTime: '2020-11-14T23:50:32.000Z', //the last point in time you want to update a version as an ISO-8601 string
     region: "ap-southeast-2" //Dynamo Region. Change for each datacenter
 }));
 ```
 This will be fine to run both on your local environment (for testing the dev datacenter) or uploaded into an EC2 instance with the appropriate permissions to access client data for backing up. Clone the repository into a machine you want to perform the task on and use node to run the script. 
+
+### Running on AWS
+Run package.ps1 to bundle up the code into LambdaFunction.zip, which is ready to upload as a Lambda function to AWS. 
+Set the handler to be index.logbuildList, give it a role with the appropriate permissions, and run it by giving it a test event in the form:
+```json
+{
+    "Prefix": "ServiceFolder/TableFolder/ClientID",
+    "DestinationTableName": "Example Table Name" , 
+    "Bucket": "au-backup-bucket-name", 
+    "restoreToPointInTime": "2020-11-14T23:50:32.000Z", 
+    "region": "ap-southeast-2" 
+}
+```
 
 ##TODO
 

--- a/example/example-restore-to-point.js
+++ b/example/example-restore-to-point.js
@@ -14,7 +14,7 @@ console.log(dynamoIncrementalRestore.logbuildList({
     Prefix: "ServiceFolder/TableFolder/ClientID",  //Adjust the InstID as needed. OR you can not provide an Inst ID and you get all the forms. e.g. Formsmith/Formsmith.Green.FormData/543
     DestinationTableName: "Example Table Name" , //The table to backup. 1 table at a time e.g. Formsmith.Green.FormData
     Bucket: "au-backup-bucket-name", //The bucket where the data is stored. e.g. pageup-dynamo-backup
-    restoreToPointInTime: new Date('2020-11-14T23:50:32.000Z'), //the last point in time you want to update a version
+    restoreToPointInTime: '2020-11-14T23:50:32.000Z', //the last point in time you want to update a version
     //restoreToPointInTime: new Date('2016-11-14T23:50:32.000Z'), 
     region: "ap-southeast-2" //Dynamo Region. Change for each datacenter
 }));

--- a/lib/buildS3VersionList.js
+++ b/lib/buildS3VersionList.js
@@ -123,7 +123,7 @@ function getVersion(params) {
 
     function _init() {
         if (params) {
-            restoreToPointInTime = params.restoreToPointInTime || new Date();
+            restoreToPointInTime = new Date(params.restoreToPointInTime) || new Date();
             s3Params.Bucket = params.Bucket || '';
             s3Params.Prefix = params.Prefix || '';
             runDeltaOnly = params.runDelta || false;

--- a/package.ps1
+++ b/package.ps1
@@ -1,0 +1,29 @@
+﻿Write-Output "Packaging Lambda app"
+if (Test-Path .\package) {
+  Remove-Item .\package -Recurse -Force
+}
+
+New-Item .\package -type directory -f | Out-Null
+New-Item .\package\temp -type directory -f | Out-Null
+Write-Output "Copying dependencies..."
+Copy-Item .\lib\buildS3VersionList.js .\package\temp\
+Copy-Item .\lib\s3ToDynamo.js .\package\temp\
+robocopy  .\node_modules\ .\package\temp\ /E | Out-Null
+Write-Output "Dependencies sorted"
+
+Write-Output "Generating output..."
+Copy-Item .\lib\index.js .\package\temp\
+Write-Output "Output generated"
+
+Add-Type -assembly "system.io.compression.filesystem"
+$currentPath = (Get-Item -Path ".\" -Verbose).FullName
+$sourcePath = $currentPath + "\package\temp"
+$outputFile = $currentPath + "\LambdaFunction.zip"
+
+if (Test-Path $outputFile) {
+  Remove-Item $outputFile -Force
+}
+
+[io.compression.zipfile]::CreateFromDirectory($sourcePath, $outputFile)
+
+Write-Output "λ function ready to be uploaded at: $($outputFile)"


### PR DESCRIPTION
This adds a powershell script that will bundle up the code for deployment to Lambda (it's mostly a copy of the one in the dynamodb-replicator repo).

Also changed the code to take the restore date as a string, to better support running the function through a lambda test event.